### PR TITLE
added support for async jobs

### DIFF
--- a/package/package.js
+++ b/package/package.js
@@ -8,7 +8,7 @@ Package.describe({
 
 Package.onUse(function(api) {
     api.versionsFrom('1.3');
-	api.use(["mongo", "random", "ecmascript", "check"], "server");
+	api.use(["mongo", "random", "ecmascript", "check", "promise"], "server");
 	api.mainModule("server/api.js", "server");
 	api.export(["Jobs", "JobsInternal"]);
 });

--- a/package/server/imports/actions/execute/process.js
+++ b/package/server/imports/actions/execute/process.js
@@ -1,9 +1,10 @@
+import { Promise } from "meteor/promise"
 import { Utilities } from "../../utilities"
 import { toolbelt } from "./toolbelt.js"
 import { reschedule } from "../reschedule/"
 
 var process = function (doc, callback) {
-	// Goals: 
+	// Goals:
 	// 1- Execute the job
 	// 2- Update the document in database
 	// 3- Capture the result (if any)
@@ -11,7 +12,8 @@ var process = function (doc, callback) {
 	var Toolbelt = new toolbelt(doc);
 
 	try {
-		var jobResult = Utilities.registry.data[doc.name].apply(Toolbelt, doc.arguments);
+		var res = Utilities.registry.data[doc.name].apply(Toolbelt, doc.arguments);
+		var jobResult = Promise.await(Promise.resolve(res));
 		var resolution = Toolbelt.checkForResolution();
 
 		if (typeof callback === "function") {
@@ -21,9 +23,9 @@ var process = function (doc, callback) {
 		}
 	}
 
-	catch (e) {		
+	catch (e) {
 		var failure = Toolbelt.failure();
-		
+
 		Utilities.logger("Job failed to run due to code error: " + doc.name)
 		console.log(e);
 


### PR DESCRIPTION
Hi!
You can use async jobs with this PR, i.e. jobs that return result like promise object.

```js
const JOB_CONFIG = {
  in: {
    seconds: 5
  }
}

const testJob = () => new Promise(resolve => {
  return Meteor.setTimeout(() => {
    console.log('ping')
    resolve()
  }, 1000)
})

Jobs.register({
  async test () {
    await testJob()
    this.success()
  }
})

Meteor.startup(() => {
  Jobs.run('test', JOB_CONFIG)
})

``` 