### PR TITLE
Fixed issues with variables not being accessed properly in toolbelt.js

### DIFF
--- a/package/server/imports/actions/execute/toolbelt.js
+++ b/package/server/imports/actions/execute/toolbelt.js
@@ -1,22 +1,22 @@
 import { Utilities } from "../../utilities"
 import { Operator } from "../../operator"
-import { reschedule } from "../reschedule/"
+import { reschedule } from "../reschedule"
 import { replicate } from "../replicate/"
 import { remove } from "../remove/"
 
-var toolbelt = function (jobDoc) {
+let toolbelt = function (jobDoc) {
 	this.document = jobDoc;
-	this.resolved = false; 
+	this.resolved = false;
 
-	this.set = function (key, value) {	
+	this.set = function (key, value) {
 		check(key, String)
 
-		var docId = this.document._id;
-		var patch = {}
+		let docId = this.document._id;
+		let patch = {}
 		patch["data." + key] = value;
 
 		// first, update the document
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$set: patch
 		})
 
@@ -31,16 +31,16 @@ var toolbelt = function (jobDoc) {
 
 	this.get = function (key, getLatestFromDatabase) {
 		check(key, String)
-		var docId = this.document._id
+		let docId = this.document._id
 
 
 		if (getLatestFromDatabase) {
 			// Get the latest doc
-			doc = Utilities.collection.findOne(docId);
+			let doc = Utilities.collection.findOne(docId);
 			
 			// Update the cached doc with the fresh copy
 			if (doc) {
-				this.document = doc;	
+				this.document = doc;
 			}
 		}
 
@@ -50,9 +50,9 @@ var toolbelt = function (jobDoc) {
 	this.push = function (key, value) {
 		check(key, String)
 
-		var docId = this.document._id;
+		let docId = this.document._id;
 
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$push: {
 				["data." + key]: value
 			}
@@ -64,9 +64,9 @@ var toolbelt = function (jobDoc) {
 	this.pull = function (key, value) {
 		check(key, String)
 
-		var docId = this.document._id;
+		let docId = this.document._id;
 
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$pull: {
 				["data." + key]: value
 			}
@@ -76,9 +76,9 @@ var toolbelt = function (jobDoc) {
 	this.pullAll = function (key, value) {
 		check(key, String)
 
-		var docId = this.document._id;
+		let docId = this.document._id;
 
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$pullAll: {
 				["data." + key]: value
 			}
@@ -90,9 +90,9 @@ var toolbelt = function (jobDoc) {
 		check(value, Number)
 		value = value || 1
 
-		var docId = this.document._id;
+		let docId = this.document._id;
 
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$inc: {
 				["data." + key]: value
 			}
@@ -104,9 +104,9 @@ var toolbelt = function (jobDoc) {
 		check(value, Number)
 		value = value || 1
 
-		var docId = this.document._id;
+		let docId = this.document._id;
 
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$dec: {
 				["data." + key]: value
 			}
@@ -118,9 +118,9 @@ var toolbelt = function (jobDoc) {
 		check(value, Number)
 		value = value || 1
 
-		var docId = this.document._id;
+		let docId = this.document._id;
 
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$addToSet: {
 				["data." + key]: value
 			}
@@ -128,12 +128,12 @@ var toolbelt = function (jobDoc) {
 	}
 
 	this.success = function (result) {
-		var docId = this.document._id;
+		let docId = this.document._id;
 
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$set: {
 				state: "success",
-			}, 
+			},
 			$push: {
 				history: {
 					date: new Date(),
@@ -150,14 +150,14 @@ var toolbelt = function (jobDoc) {
 	}
 
 	this.failure = function (result) {
-		var docId = this.document._id;
-		var queueName = this.document.name;
+		let docId = this.document._id;
+		let queueName = this.document.name;
 
 		// Update the document
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$set: {
 				state: "failure",
-			}, 
+			},
 			$push: {
 				history: {
 					date: new Date(),
@@ -170,7 +170,7 @@ var toolbelt = function (jobDoc) {
 
 		// Stop the queue
 		Utilities.logger([
-			"Job has failed: " + queueName + ", " + docId, 
+			"Job has failed: " + queueName + ", " + docId,
 			"Queue was stopped; please correct your job function and restart the server"
 		]);
 
@@ -182,34 +182,34 @@ var toolbelt = function (jobDoc) {
 	}
 
 	this.reschedule = function (config) {
-		var docId = this.document._id;
-		var newDate = reschedule(docId, config);
+		const doc = this.document;
+		let newDate = reschedule(doc._id, config);
 
 		if (!newDate) {
-			Utilities.logger(["Error rescheduling job: " + doc.name + "/" + docId, config]);
+			Utilities.logger(["Error rescheduling job: " + doc.name + "/" + doc._id, config]);
 		}
 
 		this.resolved = true;
-		return newDate;	
+		return newDate;
 	}
 
 	this.replicate = function (config) {
-		var doc = this.document;
-		var newCopy = replicate(doc, config)
+		const doc = this.document;
+		const newCopy = replicate(doc, config)
 
 		if (!newCopy) {
-			Utilities.logger(["Error cloning job: " + doc.name + "/" + docId, config]);
+			Utilities.logger(["Error cloning job: " + doc.name + "/" + doc._id, config]);
 		}
 
 		return newCopy;
 	}
 
 	this.remove = function () {
-		var docId = this.document._id;
-		var removeDoc = remove(docId)
+		const doc = this.document;
+		let removeDoc = remove(doc._id)
 
 		if (!removeDoc) {
-			Utilities.logger(["Error removing job: " + doc.name + "/" + docId, config]);
+			Utilities.logger(["Error removing job: " + doc.name + "/" + doc._id]);
 		}
 
 		this.resolved = true;
@@ -217,9 +217,9 @@ var toolbelt = function (jobDoc) {
 	}
 
 	this.clearHistory = function () {
-		var docId = this.document._id;
+		let docId = this.document._id;
 
-		var update = Utilities.collection.update(docId, {
+		let update = Utilities.collection.update(docId, {
 			$set: {
 				history: [{
 					date: new Date(),
@@ -233,8 +233,8 @@ var toolbelt = function (jobDoc) {
 	}
 
 	this.checkForResolution = function (result) {
-		var docId = this.document._id;
-		var resolution = this.resolved;
+		let docId = this.document._id;
+		let resolution = this.resolved;
 
 
 		if (!resolution) this.success(result)

--- a/package/server/imports/actions/reschedule/index.js
+++ b/package/server/imports/actions/reschedule/index.js
@@ -1,6 +1,6 @@
 import { Utilities } from "../../utilities"
 
-reschedule = function (job, config, callback) {
+function reschedule(job, config, callback) {
 	var error,
 		result,
 		jobDoc = Utilities.helpers.getJob(job, {
@@ -22,20 +22,16 @@ reschedule = function (job, config, callback) {
 		}
 
 		// Second, set the priority, if any
-		var determineNewPriority = function () {
-			if (config && config.priority) {
-				var val = Utilities.helpers.number(config.priority, "priority") || 0;
-				dbUpdate.$set.priority = val;
-				dbUpdate.$push.history.newPriority = val;
-			}
-		}();
+		if (config && config.priority) {
+			var val = Utilities.helpers.number(config.priority, "priority") || 0;
+			dbUpdate.$set.priority = val;
+			dbUpdate.$push.history.newPriority = val;
+		}
 
 		// Third, create a new date, if any
-		var newDueDate = function () {
-			var val = Utilities.helpers.generateDueDate(config);
-			dbUpdate.$set.due = val;
-			dbUpdate.$push.history.newDue = val;
-		}();
+		var val = Utilities.helpers.generateDueDate(config);
+		dbUpdate.$set.due = val;
+		dbUpdate.$push.history.newDue = val;
 
 		// Finally, run the update
 		result = Utilities.collection.update(jobDoc._id, dbUpdate)
@@ -43,7 +39,7 @@ reschedule = function (job, config, callback) {
 		error = true
 	}
 
-	// and job finished 
+	// and job finished
 	if (callback) {
 		callback(error, result);
 	}

--- a/package/server/imports/operator/index.js
+++ b/package/server/imports/operator/index.js
@@ -2,7 +2,7 @@ import { queue } from "./queue/"
 import { dominator } from "./dominator/"
 import { manager } from "./manager/"
 
-Operator = {
+const Operator = {
 	dominator: dominator,
 	queue: queue,
 	manager: manager


### PR DESCRIPTION
Ensured that uses of `doc` were initialized within their respective calling functions and set to `this.document`. Additionally, made it so that calls to `docId` were instead to `doc._id`.

Removed function calls that had void return being set to variables in reschedule/index.js

Made Operator a const so that it is more explicit as a variable for IDE parsing.